### PR TITLE
[fix] fix speed perturb and dither related bugs

### DIFF
--- a/examples/aishell/s0/conf/train_conformer.yaml
+++ b/examples/aishell/s0/conf/train_conformer.yaml
@@ -41,7 +41,7 @@ raw_wav: true
 collate_conf:
     # waveform level config
     wav_distortion_conf:
-        wav_dither: 0 # x means x/32768.0 in torchaudio
+        wav_dither: 1.0
         wav_distortion_rate: 0.0
         distortion_methods: []
     speed_perturb: false

--- a/examples/aishell/s0/conf/train_conformer.yaml
+++ b/examples/aishell/s0/conf/train_conformer.yaml
@@ -41,7 +41,7 @@ raw_wav: true
 collate_conf:
     # waveform level config
     wav_distortion_conf:
-        wav_dither: 1.0
+        wav_dither: 0.0
         wav_distortion_rate: 0.0
         distortion_methods: []
     speed_perturb: false

--- a/examples/aishell/s0/conf/train_transformer.yaml
+++ b/examples/aishell/s0/conf/train_transformer.yaml
@@ -36,7 +36,7 @@ raw_wav: true
 collate_conf:
     # waveform level config
     wav_distortion_conf:
-        wav_dither: 0.0 # x means x/32768.0 in torchaudio
+        wav_dither: 0.0
         wav_distortion_rate: 0.0
         distortion_methods: []
     speed_perturb: false

--- a/examples/aishell/s0/conf/train_unified_conformer.yaml
+++ b/examples/aishell/s0/conf/train_unified_conformer.yaml
@@ -44,7 +44,7 @@ raw_wav: true
 collate_conf:
     # waveform level config
     wav_distortion_conf:
-        wav_dither: 1.0 # x means x/32768.0 in torchaudio
+        wav_dither: 1.0
         wav_distortion_rate: 0.0
         distortion_methods: []
     speed_perturb: true

--- a/examples/aishell/s0/conf/train_unified_transformer.yaml
+++ b/examples/aishell/s0/conf/train_unified_transformer.yaml
@@ -37,7 +37,7 @@ raw_wav: true
 collate_conf:
     # waveform level config
     wav_distortion_conf:
-        wav_dither: 0.0 # x means x/32768.0 in torchaudio
+        wav_dither: 0.0
         wav_distortion_rate: 0.0
         distortion_methods: []
     speed_perturb: false

--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -126,9 +126,10 @@ def _load_wav_with_speed(wav_file, speed):
         E.append_effect_to_chain('speed', speed)
         E.append_effect_to_chain("rate", si.rate)
         E.set_input_file(wav_file)
-        return E.sox_build_flow_effects()
-
-
+        wav, sr = E.sox_build_flow_effects()
+        # sox will normalize the waveform, scale to [-32768, 32767]
+        wav = wav * (1 << 15)
+        return wav, sr
 
 def _extract_feature(batch, speed_perturb, wav_distortion_conf,
                      feature_extraction_conf):
@@ -148,7 +149,7 @@ def _extract_feature(batch, speed_perturb, wav_distortion_conf,
     keys = []
     feats = []
     lengths = []
-    wav_dither = wav_distortion_conf['wav_dither'] / 32768.0
+    wav_dither = wav_distortion_conf['wav_dither']
     wav_distortion_rate = wav_distortion_conf['wav_distortion_rate']
     distortion_methods_conf = wav_distortion_conf['distortion_methods']
     if speed_perturb:


### PR DESCRIPTION
1. Use un-normalized dither value for  [-32768,32767] waveform
2. convert speed perturbed waveform scaled in [-1,1) to  [-32768,32767] 