### PR TITLE
[fix] memory leaks

### DIFF
--- a/runtime/server/x86/frontend/wav.h
+++ b/runtime/server/x86/frontend/wav.h
@@ -107,7 +107,7 @@ class WavReader {
   int num_sample() const { return num_sample_; }
 
   ~WavReader() {
-    if (data_ != NULL) delete data_;
+    if (data_ != NULL) delete[] data_;
   }
 
   const float* data() const { return data_; }


### PR DESCRIPTION
Allocated array should be deallocated with `delete []` Deallocating it with `delete` can cause memory leaks.
[More info](https://www.viva64.com/en/examples/v611/)