### PR TITLE
flush cmvn log in time

### DIFF
--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import sys
 import argparse
 import json
 import codecs
@@ -90,7 +91,7 @@ if __name__ == '__main__':
             all_number += number
             wav_number += batch_size
             if wav_number % 1000 == 0:
-                print('process {} wavs,{} frames'.format(wav_number, all_number))
+                print(f'processed {wav_number} wavs, {all_number} frames', file=sys.stderr, flush=True)
 
     cmvn_info = {'mean_stat' : list(all_mean_stat.tolist()),
                  'var_stat' : list(all_var_stat.tolist()),

--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -91,7 +91,8 @@ if __name__ == '__main__':
             all_number += number
             wav_number += batch_size
             if wav_number % 1000 == 0:
-                print(f'processed {wav_number} wavs, {all_number} frames',
+                print(
+                    f'processed {wav_number} wavs, {all_number} frames',
                     file=sys.stderr,
                     flush=True)
 

--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -91,7 +91,9 @@ if __name__ == '__main__':
             all_number += number
             wav_number += batch_size
             if wav_number % 1000 == 0:
-                print(f'processed {wav_number} wavs, {all_number} frames', file=sys.stderr, flush=True)
+                print(f'processed {wav_number} wavs, {all_number} frames',
+                    file=sys.stderr,
+                    flush=True)
 
     cmvn_info = {'mean_stat' : list(all_mean_stat.tolist()),
                  'var_stat' : list(all_var_stat.tolist()),


### PR DESCRIPTION
1. change logging from stdout to stderr
2. Training pipeline seems halted without instant logging flush, especially when data-set is large.